### PR TITLE
zap: allow passing in available zap.Logger

### DIFF
--- a/limlog.go
+++ b/limlog.go
@@ -1,8 +1,10 @@
 package limlog
 
 import (
-	"golang.org/x/time/rate"
 	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 )
 
 type Logger interface {
@@ -52,6 +54,13 @@ func NewLimlogZap() *Limlog {
 func NewLimlogZapWithConfig(cfg interface{}) *Limlog {
 	return &Limlog{
 		L:            NewLimlogZapWithConfigImpl(cfg),
+		rateLimiters: make(map[string]*rate.Limiter),
+	}
+}
+
+func NewLimlogWithZap(zap *zap.Logger) *Limlog {
+	return &Limlog{
+		L:            &zapImpl{Zap: zap},
 		rateLimiters: make(map[string]*rate.Limiter),
 	}
 }


### PR DESCRIPTION
To allow using the `zap.Option` functional arguments for configuring Zap, we must be able to provide our own zap.Logger rather than rely on the much simpler configuration provided via the `zap.Config` object and its integration in `limlog`